### PR TITLE
Use ansicolor in colorize_lumberdash for better system support

### DIFF
--- a/plugins/colorize_lumberdash/lib/src/colorize_lumberdash.dart
+++ b/plugins/colorize_lumberdash/lib/src/colorize_lumberdash.dart
@@ -1,4 +1,4 @@
-import 'package:io/ansi.dart';
+import 'package:ansicolor/ansicolor.dart';
 import 'package:lumberdash/lumberdash.dart';
 
 /// [LumberdashClient] that colors your logs in the stdout depending
@@ -10,28 +10,33 @@ class ColorizeLumberdash extends LumberdashClient {
     print('Message { message: $message, extras: $extras }'); // no color added
   }
 
-  /// Prints the given message in yellow
+  /// Prints the given message in a yellow background with a black
+  /// font
   @override
   void logWarning(String message, [Map<String, dynamic> extras]) {
-    final warning =
-        yellow.wrap('Warning { message: $message, extras: $extras }');
-    print(warning);
+    final warning = AnsiPen()
+      ..black()
+      ..yellow(bg: true);
+    print(warning(('Warning { message: $message, extras: $extras }')));
   }
 
-  /// Prints the given message in red
+  /// Prints the given message in light red background with a white
+  /// font
   @override
   void logFatal(String message, [Map<String, dynamic> extras]) {
-    final fatal = red.wrap('Fatal { message: $message, extras: $extras }');
-    print(fatal);
+    final fatal = AnsiPen()
+      ..white()
+      ..red(bg: true);
+    print(fatal('Fatal { message: $message, extras: $extras }'));
   }
 
-  /// Printst the given message in a red background with white
-  /// characters
+  /// Printst the given message in a red background with a white
+  /// font
   @override
   void logError(dynamic exception, [dynamic stacktrace]) {
-    final error =
-        white.wrap('Error { exception: $exception, stacktrace: $stacktrace }');
-    final errorBg = backgroundRed.wrap(error);
-    print(errorBg);
+    final error = AnsiPen()
+      ..white(bold: true)
+      ..xterm(88, bg: true);
+    print(error('Error { exception: $exception, stacktrace: $stacktrace }'));
   }
 }

--- a/plugins/colorize_lumberdash/pubspec.yaml
+++ b/plugins/colorize_lumberdash/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   lumberdash:
     path: ../../
   meta: ^1.0.0
-  io: ^0.3.0
+  ansicolor: ^1.0.2
 
 dev_dependencies:
   test: ^1.4.0


### PR DESCRIPTION
This fixes #31

<img width="431" alt="Screen Shot 2019-10-21 at 8 53 24 AM" src="https://user-images.githubusercontent.com/3237451/67212008-4017bf00-f3e1-11e9-9ced-da0753b96f8c.png">
