### PR TITLE
Added ability to disable logs in release builds

### DIFF
--- a/lib/src/lumberdash.dart
+++ b/lib/src/lumberdash.dart
@@ -5,13 +5,19 @@ import 'client/client.dart';
 /// Initialize the `lumberdashClients` internally
 List<LumberdashClient> _lumberdashClients = [];
 
+/// Whether the app is running in production or development
+bool _development = false;
+
 /// As it name says, it puts Lumberdash to work by setting up its
 /// [LumberdashClient]. The full power of Lumberdash can
 /// be achieved when you use a custom [LumberdashClient], or multiple
 /// clients, that can fit your logging requirements.
-putLumberdashToWork({@required List<LumberdashClient> withClients}) {
+putLumberdashToWork({@required List<LumberdashClient> withClients, bool development}) {
   assert(withClients != null);
+  assert(_development = true);
+
   _lumberdashClients = withClients;
+  _development = development ?? _development;
 }
 
 /// It calls the `logMessage` method of the each [LumberdashClient]
@@ -23,8 +29,12 @@ String logMessage(
   String message, {
   Map<String, String> extras,
   List<Type> exceptFor: const [],
+  bool developmentOnly: false,
 }) {
-  _filterOutClientsAndLog(exceptFor, (c) => c.logMessage(message, extras));
+  if(!developmentOnly || (developmentOnly && _development)) {
+    _filterOutClientsAndLog(exceptFor, (c) => c.logMessage(message, extras));
+  }
+
   return message;
 }
 
@@ -37,8 +47,12 @@ String logWarning(
   String message, {
   Map<String, String> extras,
   List<Type> exceptFor: const [],
+  bool developmentOnly: false,
 }) {
-  _filterOutClientsAndLog(exceptFor, (c) => c.logWarning(message, extras));
+  if(!developmentOnly || (developmentOnly && _development)) {
+    _filterOutClientsAndLog(exceptFor, (c) => c.logWarning(message, extras));
+  }
+
   return message;
 }
 
@@ -51,8 +65,12 @@ String logFatal(
   String message, {
   Map<String, String> extras,
   List<Type> exceptFor: const [],
+  bool developmentOnly: false,
 }) {
-  _filterOutClientsAndLog(exceptFor, (c) => c.logFatal(message, extras));
+  if(!developmentOnly || (developmentOnly && _development)) {
+    _filterOutClientsAndLog(exceptFor, (c) => c.logFatal(message, extras));
+  }
+
   return message;
 }
 
@@ -65,8 +83,12 @@ dynamic logError(
   dynamic exception, {
   dynamic stacktrace,
   List<Type> exceptFor: const [],
+  bool developmentOnly: false,
 }) {
-  _filterOutClientsAndLog(exceptFor, (c) => c.logError(exception, stacktrace));
+  if(!developmentOnly || (developmentOnly && _development)) {
+    _filterOutClientsAndLog(exceptFor, (c) => c.logError(exception, stacktrace));
+  }
+
   return exception;
 }
 

--- a/plugins/firebase_lumberdash/example/.gitignore
+++ b/plugins/firebase_lumberdash/example/.gitignore
@@ -28,6 +28,9 @@
 .pub/
 build/
 
+.flutter-plugins-dependencies
+ios/Flutter/flutter_export_environment.sh
+
 # Android related
 **/android/**/gradle-wrapper.jar
 **/android/.gradle

--- a/test/lumberdash_test.dart
+++ b/test/lumberdash_test.dart
@@ -35,6 +35,21 @@ void main() {
       verify(mockClient.logFatal('Fatal')).called(1);
       verify(mockClient.logError('Error')).called(1);
     });
+
+    test('should not log messages in production', () {
+      final mockClient = MockClient();
+
+      putLumberdashToWork(withClients: [mockClient], development: false);
+      logMessage('Message', developmentOnly: true);
+      logWarning('Message', developmentOnly: true);
+      logError('Message', developmentOnly: true);
+      logFatal('Message', developmentOnly: true);
+
+      verifyNever(mockClient.logMessage(any));
+      verifyNever(mockClient.logWarning(any));
+      verifyNever(mockClient.logError(any));
+      verifyNever(mockClient.logFatal(any));
+    });
   });
 
   group('log API', () {


### PR DESCRIPTION
Added ability to disable logs that might be useful while developing/debugging but irrelevant or unsafe in release builds.

All log functions now have a **developmentOnly** optional parameter that will ignore the message in release builds.
