### PR TITLE
Make logError easier human readable in console

### DIFF
--- a/plugins/colorize_lumberdash/lib/src/colorize_lumberdash.dart
+++ b/plugins/colorize_lumberdash/lib/src/colorize_lumberdash.dart
@@ -37,7 +37,11 @@ class ColorizeLumberdash extends LumberdashClient {
     final error = AnsiPen()
       ..white(bold: true)
       ..xterm(88, bg: true);
-    print(error('[ERROR] { exception: $exception, stacktrace: $stacktrace }'));
+    if (stacktrace == null) {
+      print(error('[ERROR] $exception'));
+    } else {
+      print(error('[ERROR] $exception\n$stacktrace'));
+    }
   }
 
   String _format(String tag, String message, Map<String, dynamic> extras) {

--- a/plugins/file_lumberdash/lib/src/file_lumberdash.dart
+++ b/plugins/file_lumberdash/lib/src/file_lumberdash.dart
@@ -48,10 +48,10 @@ class FileLumberdash extends LumberdashClient {
   /// Records an error message
   @override
   Future<void> logError(exception, [dynamic stacktrace]) async {
-    if (stacktrace != null) {
-      _log('[ERROR] { exception: $exception, stacktrace: $stacktrace }');
+    if (stacktrace == null) {
+      print('[ERROR] $exception');
     } else {
-      _log('[ERROR] { exception: $exception }');
+      print('[ERROR] $exception\n$stacktrace');
     }
   }
 

--- a/plugins/print_lumberdash/lib/src/print_lumberdash.dart
+++ b/plugins/print_lumberdash/lib/src/print_lumberdash.dart
@@ -23,7 +23,11 @@ class PrintLumberdash extends LumberdashClient {
   /// Prints an error message
   @override
   void logError(exception, [dynamic stacktrace]) {
-    print('[ERROR] { exception: $exception, stacktrace: $stacktrace }');
+    if (stacktrace == null) {
+      print('[ERROR] $exception');
+    } else {
+      print('[ERROR] $exception\n$stacktrace');
+    }
   }
 
   void _log(String tag, String message, Map<String, dynamic> extras) {


### PR DESCRIPTION
The current output of `logError` in console is hard to scan. 

```
flutter: [ERROR] { exception: An error occured, stacktrace: #0      Auth0Authentication.refreshLogin.<anonymous closure> (package:my_app/authenticate/auth0_authentication.dart:168:11)
<asynchronous suspension>
#1      Auth0Authentication.refreshLogin.<anonymous closure> (package:my_app/authenticate/auth0_authentication.dart)
#2      Auth0Authentication.refreshLogin (package:my_app/authenticate/auth0_authentication.dart:172:6)
#3      SessionManager.autoLogin (package:my_app/src/session/session_manager.dart:39:36)
<asynchronous suspension>
```

1. The log message doesn't start with the error message but with `{ exception: `
2. The first list of the stacktrace is in the same line as the message pushing the important part out of view (without softwrap)
3. Not having `#0` at the beginning of the line breaks the parsing of stacktraces for tools. IntelliJ isn't able to collapse long stacktraces.

The proposed changed adds a newline before the stacktrace starts and removes the curly braces. The output of this change looks like this:

```
flutter: [ERROR] Auth0 lib failed while parsing the auth0 error response
#0      Auth0Authentication.refreshLogin.<anonymous closure> (package:my_app/authenticate/auth0_authentication.dart:168:11)
<asynchronous suspension>
#1      Auth0Authentication.refreshLogin.<anonymous closure> (package:my_app/authenticate/auth0_authentication.dart)
#2      Auth0Authentication.refreshLogin (package:my_app/authenticate/auth0_authentication.dart:172:6)
#3      SessionManager.autoLogin (package:my_app/src/session/session_manager.dart:39:36)
<asynchronous suspension>
#4      runhApp.<anonymous closure>.<anonymous closure> (package:my_app/app/app.dart:105:30)
<asynchronous suspension> [4 more...]
```

- [x] The error message is easy to read
- [x] Stacktrace line `#0` starts at new line
- [x] IntelliJ collapsing works
