### PR TITLE
Fix type error

### DIFF
--- a/plugins/firebase_lumberdash/lib/src/firebase_lumberdash.dart
+++ b/plugins/firebase_lumberdash/lib/src/firebase_lumberdash.dart
@@ -54,7 +54,7 @@ class FirebaseLumberdash extends LumberdashClient {
   void logError(dynamic exception, [dynamic stacktrace]) {
     firebaseAnalyticsClient.logEvent(
       name: exception?.toString() ?? 'firebase_lumberdash_error',
-      parameters: _buildParameters('ERROR', {'stacktrace': stacktrace}),
+      parameters: _buildParameters('ERROR', {'stacktrace': stacktrace.toString()}),
     );
   }
 


### PR DESCRIPTION
## Overview

Stacktrace is defined as `dynamic` but the parameters reported to Firebase are a `Map<String, String>` which leads to exception if the stacktrace is not a `String`.

This code would break:
```
try {
   // some exception is thrown
} catch (error, stacktrace) {
   logError(error, stacktrace: stacktrace);
}
```

## Changes

Just converted stacktrace to String within the plugin.