### PR TITLE
Update sentry_lumberdash to Sentry v4

### DIFF
--- a/plugins/sentry_lumberdash/README.md
+++ b/plugins/sentry_lumberdash/README.md
@@ -6,7 +6,7 @@ It sends your logs to [Sentry](https://sentry.io/welcome/) with the proper sever
 
 ## How to use
 
-Add `sentry_lumberdash` to your dependencies. Then pass an instance of `SentryLumberdash` to `lumberdash`:
+Add `sentry_lumberdash` to your dependencies. Initialize Sentry and then pass an instance of `SentryLumberdash` to `lumberdash`:
 
 ```dart
 import 'package:lumberdash/lumberdash.dart';
@@ -35,7 +35,7 @@ void initApp() {
 ```
 
 This works with 
-[sentry-dart](https://pub.dev/packages/sentry/versions/4.0.0-beta.1) and
+[sentry-dart](https://pub.dev/packages/sentry/versions) and
 [sentry-flutter](https://pub.dev/packages/sentry_flutter).
 
 ## License

--- a/plugins/sentry_lumberdash/README.md
+++ b/plugins/sentry_lumberdash/README.md
@@ -11,10 +11,21 @@ Add `sentry_lumberdash` to your dependencies. Then pass an instance of `SentryLu
 ```dart
 import 'package:lumberdash/lumberdash.dart';
 import 'package:sentry_lumberdash/sentry_lumberdash.dart';
+import 'dart:async';
+import 'package:sentry/sentry.dart';
 
-void main() {
+Future<void> main() async {
+  await Sentry.init(
+    (options) {
+      options.dsn = 'https://example@sentry.io/add-your-dsn-here';
+    },
+    appRunner: initApp, // Init your App.
+  );
+}
+
+void initApp() {
   putLumberdashToWork(
-    withClient: SentryLumberdash.withDsn(dsnKey: 'your_key'),
+    withClient: SentryLumberdash(),
   );
   logWarning('Hello Warning');
   logFatal('Hello Fatal!');
@@ -22,6 +33,10 @@ void main() {
   logError(Exception('Hello Error'));
 }
 ```
+
+This works with 
+[sentry-dart](https://pub.dev/packages/sentry/versions/4.0.0-beta.1) and
+[sentry-flutter](https://pub.dev/packages/sentry_flutter).
 
 ## License
 

--- a/plugins/sentry_lumberdash/example/lib/example.dart
+++ b/plugins/sentry_lumberdash/example/lib/example.dart
@@ -1,9 +1,15 @@
 import 'package:lumberdash/lumberdash.dart';
+import 'package:sentry/sentry.dart';
 import 'package:sentry_lumberdash/sentry_lumberdash.dart';
 
 void main() {
+  Sentry.init(
+    (options) {
+      options.dsn = 'https://example@sentry.io/add-your-dsn-here';
+    },
+  );
   putLumberdashToWork(
-    withClients: [SentryLumberdash.withDsn(dsnKey: 'your_key')],
+    withClients: [SentryLumberdash()],
   );
   logWarning('Hello Warning');
   logFatal('Hello Fatal!');

--- a/plugins/sentry_lumberdash/example/pubspec.yaml
+++ b/plugins/sentry_lumberdash/example/pubspec.yaml
@@ -6,6 +6,7 @@ environment:
   sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
+  sentry: ^4.0.0
   lumberdash: ^2.1.0
   sentry_lumberdash:
     path: ../

--- a/plugins/sentry_lumberdash/lib/src/sentry_lumberdash.dart
+++ b/plugins/sentry_lumberdash/lib/src/sentry_lumberdash.dart
@@ -1,97 +1,54 @@
 import 'package:lumberdash/lumberdash.dart';
-import 'package:meta/meta.dart';
 import 'package:sentry/sentry.dart';
 
-/// [LumberdashClient] that sends your logs to Sentry
+/// [LumberdashClient] that sends your logs to Sentry.
+/// Logs are captured as a [Breadcrumb] and exceptions are captured
+/// with [Sentry.captureException].
+///
+/// To use this client, Sentry must be initialized according to
+/// [sentry-dart](https://pub.dev/packages/sentry/versions/4.0.0-beta.1) or
+/// [sentry-flutter](https://pub.dev/packages/sentry_flutter).
+/// This [SentryLumberdash] then uses the correct Sentry configuration.
 class SentryLumberdash extends LumberdashClient {
-  static const defaultValue = 'SentryLumberdash';
-
-  final SentryClient sentryClient;
-  final String loggerName;
-  final String releaseVersion;
-  final String environment;
-
-  /// Instantiates a [LumberdashClient] with a [SentryClient],
-  /// [loggerName], [releaseVersion] and [environment], all parameters
-  /// used by the [SentryClient] when sending a log.
-  SentryLumberdash({
-    @required this.sentryClient,
-    @required this.loggerName,
-    @required this.releaseVersion,
-    @required this.environment,
-  })  : assert(sentryClient != null),
-        assert(loggerName != null),
-        assert(releaseVersion != null),
-        assert(environment != null);
-
-  /// Convenience constructor that takes a [dsnKey] for your
-  /// [SentryClient] and defaults the values of [loggerName],
-  /// [releaseVersion] and [environment].
-  factory SentryLumberdash.withDsn({
-    @required String dsnKey,
-    String loggerName = defaultValue,
-    String releaseVersion = defaultValue,
-    String environment = defaultValue,
-  }) =>
-      SentryLumberdash(
-        sentryClient: SentryClient(dsn: dsnKey),
-        loggerName: loggerName,
-        releaseVersion: releaseVersion,
-        environment: environment,
-      );
-
-  /// Sends a log to Sentry using the given [SentryClient] with level
-  /// [SeverityLevel.debug]
+  /// Sends a breadcrumb to Sentry with level [SentryLevel.info]
   @override
   void logMessage(String message, [Map<String, String> extras]) {
-    sentryClient.capture(
-        event: Event(
-      loggerName: loggerName,
-      message: message,
-      extra: extras,
-      environment: environment,
-      release: releaseVersion,
-      level: SeverityLevel.debug,
-    ));
+    Sentry.addBreadcrumb(
+      Breadcrumb(
+        level: SentryLevel.info,
+        message: message,
+        data: extras,
+      ),
+    );
   }
 
-  /// Sends a log to Sentry using the given [SentryClient] with level
-  /// [SeverityLevel.warning]
+  /// Sends a breadcrumb to Sentry with level [SentryLevel.warning]
   @override
   void logWarning(String message, [Map<String, String> extras]) {
-    sentryClient.capture(
-        event: Event(
-      loggerName: loggerName,
-      message: message,
-      extra: extras,
-      environment: environment,
-      release: releaseVersion,
-      level: SeverityLevel.warning,
-    ));
+    Sentry.addBreadcrumb(
+      Breadcrumb(
+        level: SentryLevel.warning,
+        message: message,
+        data: extras,
+      ),
+    );
   }
 
-  /// Sends a log to Sentry using the given [SentryClient] with level
-  /// [SeverityLevel.fatal]
+  /// Sends a breadcrumb to Sentry with level [SentryLevel.fatal]
   @override
   void logFatal(String message, [Map<String, String> extras]) {
-    sentryClient.capture(
-        event: Event(
-      loggerName: loggerName,
-      message: message,
-      extra: extras,
-      environment: environment,
-      release: releaseVersion,
-      level: SeverityLevel.fatal,
-    ));
+    Sentry.addBreadcrumb(
+      Breadcrumb(
+        level: SentryLevel.fatal,
+        message: message,
+        data: extras,
+      ),
+    );
   }
 
   /// Sends a crash report ([exception] and [stacktrace]) to Sentry
-  /// using the given [SentryClient]
   @override
   void logError(dynamic exception, [dynamic stacktrace]) {
-    sentryClient.captureException(
-      exception: exception,
-      stackTrace: stacktrace,
-    );
+    Sentry.captureException(exception, stackTrace: stacktrace);
   }
 }

--- a/plugins/sentry_lumberdash/lib/src/sentry_lumberdash.dart
+++ b/plugins/sentry_lumberdash/lib/src/sentry_lumberdash.dart
@@ -6,7 +6,7 @@ import 'package:sentry/sentry.dart';
 /// with [Sentry.captureException].
 ///
 /// To use this client, Sentry must be initialized according to
-/// [sentry-dart](https://pub.dev/packages/sentry/versions/4.0.0-beta.1) or
+/// [sentry-dart](https://pub.dev/packages/sentry) or
 /// [sentry-flutter](https://pub.dev/packages/sentry_flutter).
 /// This [SentryLumberdash] then uses the correct Sentry configuration.
 class SentryLumberdash extends LumberdashClient {

--- a/plugins/sentry_lumberdash/pubspec.yaml
+++ b/plugins/sentry_lumberdash/pubspec.yaml
@@ -7,12 +7,12 @@ author: Jorge Coca <jcocaramos@gmail.com>
 homepage: https://github.com/jorgecoca/lumberdash
 
 environment:
-  sdk: ">=2.4.0 <3.0.0"
+  sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
   lumberdash: ^2.1.0
   meta: ^1.0.0
-  sentry: ^2.3.1
+  sentry: ^4.0.0-beta.1
 
 dev_dependencies:
   test: ^1.4.0

--- a/plugins/sentry_lumberdash/pubspec.yaml
+++ b/plugins/sentry_lumberdash/pubspec.yaml
@@ -7,12 +7,12 @@ author: Jorge Coca <jcocaramos@gmail.com>
 homepage: https://github.com/jorgecoca/lumberdash
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.8.0 <3.0.0"
 
 dependencies:
   lumberdash: ^2.1.0
   meta: ^1.0.0
-  sentry: ^4.0.0-beta.1
+  sentry: ^4.0.0
 
 dev_dependencies:
   test: ^1.4.0


### PR DESCRIPTION
# Motivation

This PR updates Sentry to >4.0.0.
The new Sentry version has a lot of breaking changes.

I've also changed to capture logs as [breadcrumbs](https://docs.sentry.io/product/error-monitoring/breadcrumbs/) 
to be more in line on how to use Sentry. Also see [breadcrumb type default](https://develop.sentry.dev/sdk/event-payloads/breadcrumbs/#breadcrumb-types).

Relevant issues:
- https://github.com/bmw-tech/lumberdash/issues/59
- https://github.com/bmw-tech/lumberdash/pull/51