### PR TITLE
Update: plugins null safety | Version 3.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        package: ["",]
+        package: ["","plugins/colorize_lumberdash","plugins/file_lumberdash","plugins/print_lumberdash","plugins/sentry_lumberdash"]
         version: ["latest",]
     steps:
       - uses: actions/checkout@v2
@@ -42,7 +42,7 @@ jobs:
            --pause-isolates-on-exit
            --enable-vm-service=9822
            --enable-asserts
-           test/lumberdash_test.dart &
+           test/all_tests.dart &
 
       - name: Collect coverage
         working-directory: ${{ matrix.package }}
@@ -60,6 +60,37 @@ jobs:
           --out=coverage/lcov.info
           --packages=.packages
           --report-on=lib
+
+      - name: Upload coverage to codecov
+        uses: codecov/codecov-action@v1
+        with:
+          flags: ${{ matrix.package }}
+          file: ./${{ matrix.package }}/coverage/lcov.info
+  build_flutter:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        package: ["plugins/firebase_lumberdash"]
+        channel: ["stable"]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: subosito/flutter-action@v1
+        with:
+          channel: ${{ matrix.channel }}
+
+      - name: Install dependencies
+        run: flutter packages get
+        working-directory: ${{ matrix.package }}
+
+      - name: Analyze
+        run: flutter analyze
+        working-directory: ${{ matrix.package }}
+
+      - name: Run tests
+        run: flutter test --coverage --coverage-path coverage/lcov.info
+        working-directory: ${{ matrix.package }}
 
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v1

--- a/plugins/colorize_lumberdash/lib/src/colorize_lumberdash.dart
+++ b/plugins/colorize_lumberdash/lib/src/colorize_lumberdash.dart
@@ -6,14 +6,14 @@ import 'package:lumberdash/lumberdash.dart';
 class ColorizeLumberdash extends LumberdashClient {
   /// Prints a regular message to stdout without any color treatment
   @override
-  void logMessage(String message, [Map<String, String> extras]) {
+  void logMessage(String message, [Map<String, String>? extras]) {
     print(_format('MESSAGE', message, extras));
   }
 
   /// Prints the given message in a yellow background with a black
   /// font
   @override
-  void logWarning(String message, [Map<String, String> extras]) {
+  void logWarning(String message, [Map<String, String>? extras]) {
     final warning = AnsiPen()
       ..black()
       ..yellow(bg: true);
@@ -23,7 +23,7 @@ class ColorizeLumberdash extends LumberdashClient {
   /// Prints the given message in light red background with a white
   /// font
   @override
-  void logFatal(String message, [Map<String, String> extras]) {
+  void logFatal(String message, [Map<String, String>? extras]) {
     final fatal = AnsiPen()
       ..white()
       ..red(bg: true);
@@ -40,7 +40,7 @@ class ColorizeLumberdash extends LumberdashClient {
     print(error('[ERROR] { exception: $exception, stacktrace: $stacktrace }'));
   }
 
-  String _format(String tag, String message, Map<String, dynamic> extras) {
+  String _format(String tag, String message, Map<String, dynamic>? extras) {
     if (extras != null) {
       return '[$tag] $message, extras: $extras';
     } else {

--- a/plugins/colorize_lumberdash/pubspec.yaml
+++ b/plugins/colorize_lumberdash/pubspec.yaml
@@ -5,7 +5,9 @@ description: >-
 version: 3.0.0
 authors:
   - BMW Group <flutter-dev@bmwgroup.com>
-homepage: https://github.com/jorgecoca/lumberdash
+repository: https://github.com/bmw-tech/lumberdash
+issue_tracker: https://github.com/bmw-tech/lumberdash/issues
+homepage: https://bmw-tech.github.io/lumberdash/
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/plugins/colorize_lumberdash/pubspec.yaml
+++ b/plugins/colorize_lumberdash/pubspec.yaml
@@ -2,19 +2,19 @@ name: colorize_lumberdash
 description: >-
   Lumberdash plugin that colors your logs on the stdout depending on
   their severity level
-version: 2.1.0
-author: Jorge Coca <jcocaramos@gmail.com>
+version: 3.0.0
+authors:
+  - BMW Group <flutter-dev@bmwgroup.com>
 homepage: https://github.com/jorgecoca/lumberdash
 
 environment:
-  sdk: ">=2.4.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  lumberdash: ^2.1.0
-  meta: ^1.0.0
-  ansicolor: ^1.0.2
+  lumberdash: ^3.0.0
+  meta: ^1.3.0
+  ansicolor: ^2.0.0-nullsafety.0
 
 dev_dependencies:
-  test: ^1.4.0
-  test_coverage: ^0.2.0
-  mockito: ^4.0.0
+  test: ^1.16.5
+  mockito: ^5.0.0

--- a/plugins/colorize_lumberdash/test/all_tests.dart
+++ b/plugins/colorize_lumberdash/test/all_tests.dart
@@ -1,0 +1,5 @@
+import 'colorize_lumberdash_test.dart' as colorized_lumberdash_test;
+
+void main() {
+  colorized_lumberdash_test.main();
+}

--- a/plugins/file_lumberdash/lib/src/file_lumberdash.dart
+++ b/plugins/file_lumberdash/lib/src/file_lumberdash.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:lumberdash/lumberdash.dart';
 import 'package:synchronized/synchronized.dart';
-import 'package:meta/meta.dart';
 
 /// [LumberdashClient] that writes your logs to the given file path
 /// in the file system
@@ -11,13 +10,12 @@ class FileLumberdash extends LumberdashClient {
   static final _lock = Lock();
 
   FileLumberdash({
-    @required String filePath,
-  })  : assert(filePath != null),
-        _logFile = File(filePath);
+    required String filePath,
+  }) : _logFile = File(filePath);
 
   /// Records a regular message
   @override
-  void logMessage(String message, [Map<String, String> extras]) {
+  void logMessage(String message, [Map<String, String>? extras]) {
     if (extras != null) {
       _log('[MESSAGE] $message, extras: $extras');
     } else {
@@ -27,7 +25,7 @@ class FileLumberdash extends LumberdashClient {
 
   /// Records a warning message
   @override
-  void logWarning(String message, [Map<String, String> extras]) {
+  void logWarning(String message, [Map<String, String>? extras]) {
     if (extras != null) {
       _log('[WARNING] $message, extras: $extras');
     } else {
@@ -37,7 +35,7 @@ class FileLumberdash extends LumberdashClient {
 
   /// Records a fatal message
   @override
-  void logFatal(String message, [Map<String, String> extras]) {
+  void logFatal(String message, [Map<String, String>? extras]) {
     if (extras != null) {
       _log('[FATAL] $message, extras: $extras');
     } else {

--- a/plugins/file_lumberdash/pubspec.yaml
+++ b/plugins/file_lumberdash/pubspec.yaml
@@ -2,16 +2,17 @@ name: file_lumberdash
 description: Lumberdash package that outputs your logs to the file system.
 version: 0.0.1
 homepage: https://bmw-tech.github.io/lumberdash/
-
+authors:
+  - BMW Group <flutter-dev@bmwgroup.com>
+  
 environment:
-  sdk: ">=2.4.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  lumberdash: ^2.1.0
-  meta: ^1.0.0
-  synchronized: ^2.2.0
+  lumberdash: ^3.0.0
+  meta: ^1.3.0
+  synchronized: ^3.0.0
 
 dev_dependencies:
-  test: ^1.4.0
-  test_coverage: ^0.2.0
-  mockito: ^4.0.0
+  test: ^1.16.5
+  mockito: ^5.0.0

--- a/plugins/file_lumberdash/pubspec.yaml
+++ b/plugins/file_lumberdash/pubspec.yaml
@@ -1,6 +1,8 @@
 name: file_lumberdash
 description: Lumberdash package that outputs your logs to the file system.
 version: 0.0.1
+repository: https://github.com/bmw-tech/lumberdash
+issue_tracker: https://github.com/bmw-tech/lumberdash/issues
 homepage: https://bmw-tech.github.io/lumberdash/
 authors:
   - BMW Group <flutter-dev@bmwgroup.com>

--- a/plugins/file_lumberdash/test/all_tests.dart
+++ b/plugins/file_lumberdash/test/all_tests.dart
@@ -1,0 +1,5 @@
+import 'file_lumberdash_test.dart' as file_lumberdash_test;
+
+void main() {
+  file_lumberdash_test.main();
+}

--- a/plugins/file_lumberdash/test/file_lumberdash_test.dart
+++ b/plugins/file_lumberdash/test/file_lumberdash_test.dart
@@ -15,14 +15,5 @@ void main() {
         fail('Exception occured when creating a FileLumberdash: $e');
       }
     });
-
-    test('create instance with a null filePath should throw', () {
-      try {
-        FileLumberdash(filePath: null);
-        fail('Should throw an exception');
-      } catch (e) {
-        expect(e is AssertionError, isTrue);
-      }
-    });
   });
 }

--- a/plugins/firebase_lumberdash/CHANGELOG.md
+++ b/plugins/firebase_lumberdash/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v3.0.0
+
+- Added support for nullsafety
+- Added support for lumberdash v3
+
 # v2.2.0 (October 5th, 2020)
 
 - Update `firebase_lumberdash` to `firebase_analytics ^6.0.1`

--- a/plugins/firebase_lumberdash/CHANGELOG.md
+++ b/plugins/firebase_lumberdash/CHANGELOG.md
@@ -1,6 +1,5 @@
 # v3.0.0
 
-- Added support for nullsafety
 - Added support for lumberdash v3
 
 # v2.2.0 (October 5th, 2020)

--- a/plugins/firebase_lumberdash/example/pubspec.yaml
+++ b/plugins/firebase_lumberdash/example/pubspec.yaml
@@ -4,12 +4,12 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
-  lumberdash: ^2.1.0
+  lumberdash: ^3.0.0
   firebase_lumberdash:
     path: ../
 

--- a/plugins/firebase_lumberdash/example/pubspec.yaml
+++ b/plugins/firebase_lumberdash/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.11.0 <3.0.0'
 
 dependencies:
   flutter:

--- a/plugins/firebase_lumberdash/example/pubspec.yaml
+++ b/plugins/firebase_lumberdash/example/pubspec.yaml
@@ -1,5 +1,5 @@
 name: example
-description: Example project for Lumberjack
+description: Example project for Lumberdash
 version: 1.0.0
 publish_to: none
 

--- a/plugins/firebase_lumberdash/lib/src/firebase_lumberdash.dart
+++ b/plugins/firebase_lumberdash/lib/src/firebase_lumberdash.dart
@@ -12,14 +12,14 @@ class FirebaseLumberdash extends LumberdashClient {
   /// client, [releaseVersion] and [environment], all parameters
   /// used by the [FirebaseAnalytics] client when sending a log.
   FirebaseLumberdash({
-    required this.firebaseAnalyticsClient,
-    required this.releaseVersion,
-    required this.environment,
+    this.firebaseAnalyticsClient,
+    this.releaseVersion,
+    this.environment,
   });
 
   /// Sends a log to Firebase Analytics using the given [FirebaseAnalytics] client
   @override
-  void logMessage(String message, [Map<String, String>? extras]) {
+  void logMessage(String message, [Map<String, String> extras]) {
     firebaseAnalyticsClient.logEvent(
       name: message,
       parameters: _buildParameters('MESSAGE', extras),
@@ -29,7 +29,7 @@ class FirebaseLumberdash extends LumberdashClient {
   /// Sends a log to Firebase Analytics using the given [FirebaseAnalytics] with level
   /// warning.
   @override
-  void logWarning(String message, [Map<String, String>? extras]) {
+  void logWarning(String message, [Map<String, String> extras]) {
     firebaseAnalyticsClient.logEvent(
       name: message,
       parameters: _buildParameters('WARNING', extras),
@@ -39,7 +39,7 @@ class FirebaseLumberdash extends LumberdashClient {
   /// Sends a log to Firebase Analytics using the given [FirebaseAnalytics] with level
   /// fatal.
   @override
-  void logFatal(String message, [Map<String, String>? extras]) {
+  void logFatal(String message, [Map<String, String> extras]) {
     firebaseAnalyticsClient.logEvent(
       name: message,
       parameters: _buildParameters('FATAL', extras),
@@ -56,11 +56,11 @@ class FirebaseLumberdash extends LumberdashClient {
     );
   }
 
-  Map<String, String?> _buildParameters(
+  Map<String, String> _buildParameters(
     String logLevel,
-    Map<String, String?>? extras,
+    Map<String, String> extras,
   ) {
-    Map<String, String?> parameters = {
+    Map<String, String> parameters = {
       'environment': environment,
       'release': releaseVersion,
       'level': logLevel,

--- a/plugins/firebase_lumberdash/lib/src/firebase_lumberdash.dart
+++ b/plugins/firebase_lumberdash/lib/src/firebase_lumberdash.dart
@@ -1,5 +1,5 @@
 import 'package:lumberdash/lumberdash.dart';
-import 'package:meta/meta.dart';
+// ignore: import_of_legacy_library_into_null_safe
 import 'package:firebase_analytics/firebase_analytics.dart';
 
 /// [LumberdashClient] that sends your logs to Firebase Analytics
@@ -12,16 +12,14 @@ class FirebaseLumberdash extends LumberdashClient {
   /// client, [releaseVersion] and [environment], all parameters
   /// used by the [FirebaseAnalytics] client when sending a log.
   FirebaseLumberdash({
-    @required this.firebaseAnalyticsClient,
-    @required this.releaseVersion,
-    @required this.environment,
-  })  : assert(firebaseAnalyticsClient != null),
-        assert(releaseVersion != null),
-        assert(environment != null);
+    required this.firebaseAnalyticsClient,
+    required this.releaseVersion,
+    required this.environment,
+  });
 
   /// Sends a log to Firebase Analytics using the given [FirebaseAnalytics] client
   @override
-  void logMessage(String message, [Map<String, String> extras]) {
+  void logMessage(String message, [Map<String, String>? extras]) {
     firebaseAnalyticsClient.logEvent(
       name: message,
       parameters: _buildParameters('MESSAGE', extras),
@@ -31,7 +29,7 @@ class FirebaseLumberdash extends LumberdashClient {
   /// Sends a log to Firebase Analytics using the given [FirebaseAnalytics] with level
   /// warning.
   @override
-  void logWarning(String message, [Map<String, String> extras]) {
+  void logWarning(String message, [Map<String, String>? extras]) {
     firebaseAnalyticsClient.logEvent(
       name: message,
       parameters: _buildParameters('WARNING', extras),
@@ -41,7 +39,7 @@ class FirebaseLumberdash extends LumberdashClient {
   /// Sends a log to Firebase Analytics using the given [FirebaseAnalytics] with level
   /// fatal.
   @override
-  void logFatal(String message, [Map<String, String> extras]) {
+  void logFatal(String message, [Map<String, String>? extras]) {
     firebaseAnalyticsClient.logEvent(
       name: message,
       parameters: _buildParameters('FATAL', extras),
@@ -58,11 +56,11 @@ class FirebaseLumberdash extends LumberdashClient {
     );
   }
 
-  Map<String, String> _buildParameters(
+  Map<String, String?> _buildParameters(
     String logLevel,
-    Map<String, String> extras,
+    Map<String, String?>? extras,
   ) {
-    Map<String, String> parameters = {
+    Map<String, String?> parameters = {
       'environment': environment,
       'release': releaseVersion,
       'level': logLevel,

--- a/plugins/firebase_lumberdash/pubspec.yaml
+++ b/plugins/firebase_lumberdash/pubspec.yaml
@@ -4,7 +4,9 @@ description: >-
 version: 3.0.0
 authors:
   - BMW Group <flutter-dev@bmwgroup.com>
-homepage: https://github.com/jorgecoca/lumberdash
+repository: https://github.com/bmw-tech/lumberdash
+issue_tracker: https://github.com/bmw-tech/lumberdash/issues
+homepage: https://bmw-tech.github.io/lumberdash/
 
 environment:
   sdk: '>=2.11.0 <3.0.0'

--- a/plugins/firebase_lumberdash/pubspec.yaml
+++ b/plugins/firebase_lumberdash/pubspec.yaml
@@ -1,23 +1,22 @@
 name: firebase_lumberdash
 description: >-
   Lumberdash plugin that sends your logs to Firebase Analytics
-version: 2.2.0
+version: 3.0.0
 authors:
-  - Felix Angelov <felangelov@gmail.com>
-  - Jorge Coca <jcocaramos@gmail.com>
+  - BMW Group <flutter-dev@bmwgroup.com>
 homepage: https://github.com/jorgecoca/lumberdash
 
 environment:
-  sdk: ">=2.4.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
-  lumberdash: ^2.1.0
-  meta: ^1.0.0
-  firebase_analytics: ^6.0.1
+  lumberdash: ^3.0.0
+  meta: ^1.3.0
+  firebase_analytics: ^7.1.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: ^4.0.0
+  mockito: ^5.0.0

--- a/plugins/firebase_lumberdash/pubspec.yaml
+++ b/plugins/firebase_lumberdash/pubspec.yaml
@@ -7,7 +7,7 @@ authors:
 homepage: https://github.com/jorgecoca/lumberdash
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.11.0 <3.0.0'
 
 dependencies:
   flutter:

--- a/plugins/firebase_lumberdash/test/all_test.dart
+++ b/plugins/firebase_lumberdash/test/all_test.dart
@@ -1,0 +1,5 @@
+import 'firebase_lumberdash_test.dart' as firebase_lumberdash_test;
+
+void main() {
+  firebase_lumberdash_test.main();
+}

--- a/plugins/firebase_lumberdash/test/firebase_lumberdash_test.dart
+++ b/plugins/firebase_lumberdash/test/firebase_lumberdash_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+// ignore: import_of_legacy_library_into_null_safe
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_lumberdash/firebase_lumberdash.dart';
 
@@ -7,8 +8,8 @@ class MockFirebaseAnalytics extends Mock implements FirebaseAnalytics {}
 
 main() {
   group('Firebase Lumberdash', () {
-    MockFirebaseAnalytics firebaseAnalytics;
-    FirebaseLumberdash firebaseLumberdash;
+    late MockFirebaseAnalytics firebaseAnalytics;
+    late FirebaseLumberdash firebaseLumberdash;
     String releaseVersion = '1.0.0';
     String environment = 'development';
     Map<String, String> extras = {
@@ -28,37 +29,14 @@ main() {
     group('initialization', () {
       test('throws AssertionError when firebaseAnalyticsClient is null', () {
         try {
-          FirebaseLumberdash(
-            firebaseAnalyticsClient: null,
+          final firebaseLumberdash = FirebaseLumberdash(
+            firebaseAnalyticsClient: firebaseAnalytics,
             releaseVersion: releaseVersion,
             environment: environment,
           );
+          expect(firebaseLumberdash, isA<FirebaseLumberdash>());
         } catch (error) {
-          expect(error, isAssertionError);
-        }
-      });
-
-      test('throws AssertionError when releaseVersion is null', () {
-        try {
-          FirebaseLumberdash(
-            firebaseAnalyticsClient: firebaseAnalytics,
-            releaseVersion: null,
-            environment: environment,
-          );
-        } catch (error) {
-          expect(error, isAssertionError);
-        }
-      });
-
-      test('throws AssertionError when environment is null', () {
-        try {
-          FirebaseLumberdash(
-            firebaseAnalyticsClient: firebaseAnalytics,
-            releaseVersion: releaseVersion,
-            environment: null,
-          );
-        } catch (error) {
-          expect(error, isAssertionError);
+          fail('Shouldnt throw an error');
         }
       });
     });

--- a/plugins/firebase_lumberdash/test/firebase_lumberdash_test.dart
+++ b/plugins/firebase_lumberdash/test/firebase_lumberdash_test.dart
@@ -8,8 +8,8 @@ class MockFirebaseAnalytics extends Mock implements FirebaseAnalytics {}
 
 main() {
   group('Firebase Lumberdash', () {
-    late MockFirebaseAnalytics firebaseAnalytics;
-    late FirebaseLumberdash firebaseLumberdash;
+    MockFirebaseAnalytics firebaseAnalytics;
+    FirebaseLumberdash firebaseLumberdash;
     String releaseVersion = '1.0.0';
     String environment = 'development';
     Map<String, String> extras = {

--- a/plugins/print_lumberdash/CHANGELOG.md
+++ b/plugins/print_lumberdash/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
-## v2.1.0
+# v3.0.0
+
+- Added support for nullsafety
+- Added support for lumberdash v3
+
+# v2.1.0
 
 - Make `extras` strongly typed
 
-## v2.0.0
+# v2.0.0
 
 - Support for lumberdash v2

--- a/plugins/print_lumberdash/lib/src/print_lumberdash.dart
+++ b/plugins/print_lumberdash/lib/src/print_lumberdash.dart
@@ -4,19 +4,19 @@ import 'package:lumberdash/lumberdash.dart';
 class PrintLumberdash extends LumberdashClient {
   /// Prints a regular message
   @override
-  void logMessage(String message, [Map<String, String> extras]) {
+  void logMessage(String message, [Map<String, String>? extras]) {
     _log('MESSAGE', message, extras);
   }
 
   /// Prints a warning message
   @override
-  void logWarning(String message, [Map<String, String> extras]) {
+  void logWarning(String message, [Map<String, String>? extras]) {
     _log('WARNING', message, extras);
   }
 
   /// Prints a fatal message
   @override
-  void logFatal(String message, [Map<String, String> extras]) {
+  void logFatal(String message, [Map<String, String>? extras]) {
     _log('FATAL', message, extras);
   }
 
@@ -26,7 +26,7 @@ class PrintLumberdash extends LumberdashClient {
     print('[ERROR] { exception: $exception, stacktrace: $stacktrace }');
   }
 
-  void _log(String tag, String message, Map<String, dynamic> extras) {
+  void _log(String tag, String message, Map<String, dynamic>? extras) {
     if (extras != null) {
       print('[$tag] $message, extras: $extras');
     } else {

--- a/plugins/print_lumberdash/pubspec.yaml
+++ b/plugins/print_lumberdash/pubspec.yaml
@@ -4,7 +4,9 @@ description: >-
 version: 3.0.0
 authors:
   - BMW Group <flutter-dev@bmwgroup.com>
-homepage: https://github.com/jorgecoca/lumberdash
+repository: https://github.com/bmw-tech/lumberdash
+issue_tracker: https://github.com/bmw-tech/lumberdash/issues
+homepage: https://bmw-tech.github.io/lumberdash/
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/plugins/print_lumberdash/pubspec.yaml
+++ b/plugins/print_lumberdash/pubspec.yaml
@@ -1,18 +1,18 @@
 name: print_lumberdash
 description: >-
   Lumberdash plugin that uses print() to output your logs
-version: 2.1.0
-author: Jorge Coca <jcocaramos@gmail.com>
+version: 3.0.0
+authors:
+  - BMW Group <flutter-dev@bmwgroup.com>
 homepage: https://github.com/jorgecoca/lumberdash
 
 environment:
-  sdk: ">=2.4.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  lumberdash: ^2.1.0
-  meta: ^1.0.0
+  lumberdash: ^3.0.0
+  meta: ^1.3.0
   
 dev_dependencies:
-  test: ^1.4.0
-  test_coverage: ^0.2.0
-  mockito: ^4.0.0
+  test: ^1.16.5
+  mockito: ^5.0.0

--- a/plugins/print_lumberdash/test/all_tests.dart
+++ b/plugins/print_lumberdash/test/all_tests.dart
@@ -1,0 +1,5 @@
+import 'print_lumberdash_test.dart' as print_lumberdash_test;
+
+void main() {
+  print_lumberdash_test.main();
+}

--- a/plugins/sentry_lumberdash/CHANGELOG.md
+++ b/plugins/sentry_lumberdash/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v3.0.0
+
+- Added support for nullsafety
+- Added support for lumberdash v3
 # v2.1.0
 
 - Make `extras` strongly typed

--- a/plugins/sentry_lumberdash/lib/src/sentry_lumberdash.dart
+++ b/plugins/sentry_lumberdash/lib/src/sentry_lumberdash.dart
@@ -12,7 +12,7 @@ import 'package:sentry/sentry.dart';
 class SentryLumberdash extends LumberdashClient {
   /// Sends a breadcrumb to Sentry with level [SentryLevel.info]
   @override
-  void logMessage(String message, [Map<String, String> extras]) {
+  void logMessage(String message, [Map<String, String>? extras]) {
     Sentry.addBreadcrumb(
       Breadcrumb(
         level: SentryLevel.info,
@@ -24,7 +24,7 @@ class SentryLumberdash extends LumberdashClient {
 
   /// Sends a breadcrumb to Sentry with level [SentryLevel.warning]
   @override
-  void logWarning(String message, [Map<String, String> extras]) {
+  void logWarning(String message, [Map<String, String>? extras]) {
     Sentry.addBreadcrumb(
       Breadcrumb(
         level: SentryLevel.warning,
@@ -36,7 +36,7 @@ class SentryLumberdash extends LumberdashClient {
 
   /// Sends a breadcrumb to Sentry with level [SentryLevel.fatal]
   @override
-  void logFatal(String message, [Map<String, String> extras]) {
+  void logFatal(String message, [Map<String, String>? extras]) {
     Sentry.addBreadcrumb(
       Breadcrumb(
         level: SentryLevel.fatal,

--- a/plugins/sentry_lumberdash/pubspec.yaml
+++ b/plugins/sentry_lumberdash/pubspec.yaml
@@ -5,7 +5,9 @@ description: >-
 version: 3.0.0
 authors:
   - BMW Group <flutter-dev@bmwgroup.com>
-homepage: https://github.com/jorgecoca/lumberdash
+repository: https://github.com/bmw-tech/lumberdash
+issue_tracker: https://github.com/bmw-tech/lumberdash/issues
+homepage: https://bmw-tech.github.io/lumberdash/
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/plugins/sentry_lumberdash/pubspec.yaml
+++ b/plugins/sentry_lumberdash/pubspec.yaml
@@ -2,19 +2,19 @@ name: sentry_lumberdash
 description: >-
   Lumberdash plugin that sends your logs to Sentry with the proper
   severity level
-version: 2.1.0
-author: Jorge Coca <jcocaramos@gmail.com>
+version: 3.0.0
+authors:
+  - BMW Group <flutter-dev@bmwgroup.com>
 homepage: https://github.com/jorgecoca/lumberdash
 
 environment:
-  sdk: ">=2.8.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  lumberdash: ^2.1.0
-  meta: ^1.0.0
-  sentry: ^4.0.0
+  lumberdash: ^3.0.0
+  meta: ^1.3.0
+  sentry: ^4.1.0-nullsafety.0
 
 dev_dependencies:
-  test: ^1.4.0
-  test_coverage: ^0.2.0
-  mockito: ^4.0.0
+  test: ^1.16.5
+  mockito: ^5.0.0

--- a/plugins/sentry_lumberdash/test/all_tests.dart
+++ b/plugins/sentry_lumberdash/test/all_tests.dart
@@ -1,0 +1,5 @@
+import 'sentry_lumberdash_test.dart' as sentry_lumberdash_test;
+
+void main() {
+  sentry_lumberdash_test.main();
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,8 +5,7 @@ description: >-
   cover all your logging needs.
 version: 3.0.0
 authors:
-  - Jorge Coca <jcocaramos@gmail.com>
-  - Felix Angelov <felangelov@gmail.com>
+  - BMW Group <flutter-dev@bmwgroup.com>
 repository: https://github.com/bmw-tech/lumberdash
 issue_tracker: https://github.com/bmw-tech/lumberdash/issues
 homepage: https://bmw-tech.github.io/lumberdash/

--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -1,0 +1,5 @@
+import 'lumberdash_test.dart' as lumberdash_test;
+
+void main() {
+  lumberdash_test.main();
+}


### PR DESCRIPTION
Changes:

- Updated plugins to support Lumberdash 3.0.0
- Plugins are also null safe right now except for firebase_lumberdash, since firebase_analytics is not null safe at this moment (7.0.1)
- Updated the CI script to check more modules other than just the root, plus support flutter modules.
- Created an `all_tests.dart` at the root of the test that will call all test files `main` methods. This is necessary for the CI call a common test file name, since we are no longer using the test_coverage package .